### PR TITLE
Test: Add more unit tests, refactor file/test naming

### DIFF
--- a/src/dtd_parser/dtd_parser.py
+++ b/src/dtd_parser/dtd_parser.py
@@ -7,6 +7,7 @@ DTD_ATTRIBUTE_TAG_BEGINNING = "<!ATTLIST"
 
 
 def _get_token_children(token: str):
+
     splitter = r'[\s,)(]'
     return list(filter(None, re.split(splitter, token)[2:-1]))
 
@@ -178,7 +179,6 @@ class DTDParser:
                 else:  # Default Value
                     attribute.value_type = DTDAttributeValueType.VALUE
                     attribute.value = list(filter(None, re.split(r'[>]+', token_after_type)))[0].strip('"')
-
 
         if element_name not in self.attributes.keys():
             self.attributes[element_name] = []

--- a/test/dtd_parser/test_parse_tokens.py
+++ b/test/dtd_parser/test_parse_tokens.py
@@ -1,0 +1,46 @@
+import unittest
+from src.dtd_parser.dtd_parser import DTDParser
+from src.project_path.project_path import ProjectPath
+from src.dtd_attribute.dtd_attribute import DTDAttributeType, DTDAttributeValueType
+
+
+def count_attributes(attributes: dict) -> int:
+    return sum(len(attributes[attr]) for attr in attributes.keys())
+
+
+class TestDTDParserParseTokens(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dataPath = ProjectPath.get_project_data_dtd_path()
+
+    def test_1element(self):
+        parser = DTDParser()
+        parser.load(self.dataPath / '1element.dtd')
+        self.assertEqual(len(parser.elements), 1)
+        self.assertEqual(count_attributes(parser.attributes), 0)
+
+    def test_1element_1attribute(self):
+        parser = DTDParser()
+        parser.load(self.dataPath / '1element_1attribute.dtd')
+        self.assertEqual(len(parser.elements), 1)
+        self.assertEqual(count_attributes(parser.attributes), 1)
+
+        self.assertEqual(parser.attributes["square"][0].attribute_name, "width")
+        self.assertEqual(parser.attributes["square"][0].value, "0")
+        self.assertEqual(parser.attributes["square"][0].attribute_type, DTDAttributeType.CDATA)
+        self.assertEqual(parser.attributes["square"][0].value_type, DTDAttributeValueType.VALUE)
+
+    def test_9elements_3attributes(self):
+        parser = DTDParser()
+        parser.load(self.dataPath / '9elements_3attributes.dtd')
+        self.assertEqual(len(parser.elements.keys()), 9)
+        self.assertEqual(count_attributes(parser.attributes), 3)
+
+        self.assertEqual(parser.attributes["game"][0].value_type, DTDAttributeValueType.REQUIRED)
+        self.assertEqual(len(parser.attributes["score"]), 2)
+
+    def test_11elements_6attributes(self):
+        parser = DTDParser()
+        parser.load(self.dataPath / '11elements_6attributes.dtd')
+        self.assertEqual(len(parser.elements.keys()), 11)
+        self.assertEqual(count_attributes(parser.attributes), 6)
+

--- a/test/dtd_parser/test_parse_tokens_exceptions.py
+++ b/test/dtd_parser/test_parse_tokens_exceptions.py
@@ -3,11 +3,10 @@ from src.dtd_parser.dtd_parser import DTDParser
 from src.project_path.project_path import ProjectPath
 
 
-class TestDTDParserTokenizeContent(unittest.TestCase):
+class TestDTDParserParseTokensExceptions(unittest.TestCase):
     def setUp(self) -> None:
         self.dataPath = ProjectPath.get_project_data_dtd_path()
 
-    def test_3(self):
+    def test_non_dtd_tags(self):
         parser = DTDParser()
-        parser.load(self.dataPath / '1element_6attributes.dtd')
-        self.assertEqual(len(parser._tokens), 7)
+        self.assertRaises(ValueError, parser.load, self.dataPath / 'invalid_token.dtd')

--- a/test/dtd_parser/test_read_file_content.py
+++ b/test/dtd_parser/test_read_file_content.py
@@ -7,9 +7,6 @@ class TestDTDParserReadFileContent(unittest.TestCase):
     def setUp(self) -> None:
         self.dataPath = ProjectPath.get_project_data_dtd_path()
 
-    def test_file_not_found(self):
-        self.assertRaises(FileNotFoundError, DTDParser, self.dataPath / '.file_does_not_exist_gibberish.dtd.')
-
     def test_1element(self):
         parser = DTDParser(self.dataPath / '1element.dtd')
         self.assertEqual(parser._content.strip(), "<!ELEMENT note (#PCDATA)>")
@@ -18,3 +15,8 @@ class TestDTDParserReadFileContent(unittest.TestCase):
         parser = DTDParser()
         parser.load(self.dataPath / '2nested_elements.dtd')
         self.assertEqual(parser._content.strip(), "<!ELEMENT note (heading)>\n<!ELEMENT heading (#PCDATA)>")
+
+    def test_1element_1attribute(self):
+        parser = DTDParser()
+        parser.load(self.dataPath / '1element_1attribute.dtd')
+        self.assertEqual(parser._content.strip(), "<!ELEMENT square EMPTY>\n<!ATTLIST square width CDATA \"0\">")

--- a/test/dtd_parser/test_read_file_content_exceptions.py
+++ b/test/dtd_parser/test_read_file_content_exceptions.py
@@ -1,0 +1,15 @@
+import unittest
+from src.dtd_parser.dtd_parser import DTDParser
+from src.project_path.project_path import ProjectPath
+
+
+class TestDTDParserReadFileContentExceptions(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dataPath = ProjectPath.get_project_data_dtd_path()
+
+    def test_file_not_found(self):
+        self.assertRaises(FileNotFoundError, DTDParser, self.dataPath / '.file_does_not_exist_gibberish.dtd.')
+
+    def test_non_dtd_tags(self):
+        parser = DTDParser()
+        self.assertRaises(ValueError, parser.load, self.dataPath / 'non_dtd_tags.dtd')

--- a/test/dtd_parser/test_tokenize_content_attributes.py
+++ b/test/dtd_parser/test_tokenize_content_attributes.py
@@ -1,0 +1,33 @@
+import unittest
+from src.dtd_parser.dtd_parser import DTDParser
+from src.project_path.project_path import ProjectPath
+
+
+class TestDTDParserTokenizeAttributes(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dataPath = ProjectPath.get_project_data_dtd_path()
+
+    def test_1element_1attribute(self):
+        parser = DTDParser()
+        parser.load(self.dataPath / '1element_1attribute.dtd')
+        self.assertEqual(len(parser._tokens), 2)
+
+    def test_1element_6attributes(self):
+        parser = DTDParser()
+        parser.load(self.dataPath / '1element_6attributes.dtd')
+        self.assertEqual(len(parser._tokens), 7)
+
+    def test_1element_2attributes(self):
+        parser = DTDParser()
+        parser.load(self.dataPath / '1element_2attributes.dtd')
+        self.assertEqual(len(parser._tokens), 3)
+
+    def test_9elements_3attributes(self):
+        parser = DTDParser()
+        parser.load(self.dataPath / '9elements_3attributes.dtd')
+        self.assertEqual(len(parser._tokens), 12)
+
+    def test_11elements_6attributes(self):
+        parser = DTDParser()
+        parser.load(self.dataPath / '11elements_6attributes.dtd')
+        self.assertEqual(len(parser._tokens), 17)

--- a/test/dtd_parser/test_tokenize_content_elements.py
+++ b/test/dtd_parser/test_tokenize_content_elements.py
@@ -3,21 +3,26 @@ from src.dtd_parser.dtd_parser import DTDParser
 from src.project_path.project_path import ProjectPath
 
 
-class TestDTDParserTokenizeContent(unittest.TestCase):
+class TestDTDParserTokenizeElements(unittest.TestCase):
     def setUp(self) -> None:
         self.dataPath = ProjectPath.get_project_data_dtd_path()
 
-    def test_0(self):
+    def test_1element(self):
         parser = DTDParser()
         parser.load(self.dataPath / '1element.dtd')
         self.assertEqual(len(parser._tokens), 1)
 
-    def test_1(self):
+    def test_2nested_elements(self):
         parser = DTDParser()
         parser.load(self.dataPath / '2nested_elements.dtd')
         self.assertEqual(len(parser._tokens), 2)
 
-    def test_2(self):
+    def test_5nested_elements(self):
         parser = DTDParser()
         parser.load(self.dataPath / '5nested_elements.dtd')
         self.assertEqual(len(parser._tokens), 5)
+
+    def test_12elements(self):
+        parser = DTDParser()
+        parser.load(self.dataPath / '12elements.dtd')
+        self.assertEqual(len(parser._tokens), 12)

--- a/test/dtd_parser/test_tokenize_content_exceptions.py
+++ b/test/dtd_parser/test_tokenize_content_exceptions.py
@@ -3,7 +3,7 @@ from src.dtd_parser.dtd_parser import DTDParser
 from src.project_path.project_path import ProjectPath
 
 
-class TestDTDParserTokenizeContent(unittest.TestCase):
+class TestDTDParserTokenizeExceptions(unittest.TestCase):
     def setUp(self) -> None:
         self.dataPath = ProjectPath.get_project_data_dtd_path()
 
@@ -13,11 +13,7 @@ class TestDTDParserTokenizeContent(unittest.TestCase):
         self.assertEqual(len(parser._tokens), 0)
         self.assertEqual(parser._content, "")
 
-    def test_not_dtd_file(self):
+    def test_dtd_mixed_with_text(self):
         parser = DTDParser()
         self.assertRaises(ValueError, parser.load, self.dataPath / 'dtd_mixed_with_text.txt')
         self.assertEqual(len(parser._tokens), 0)
-
-    def test_invalid_tags(self):
-        parser = DTDParser()
-        self.assertRaises(ValueError, parser.load, self.dataPath / 'non_dtd_tags.dtd')


### PR DESCRIPTION
Add tests for reading file into string, tokenizing the
read file, parsing the tokens and exceptions that these
operations can throw.
Refactored file names, removing dtd_parser prefix as they
are already in a directory dtd_parser/.
Move some of the old tests into the new files to categorize
them better.
Refactor test names to better represent what they are testing.