### PR TITLE
Feat: Add DTD element class

### DIFF
--- a/src/dtd_element/dtd_element.py
+++ b/src/dtd_element/dtd_element.py
@@ -1,0 +1,29 @@
+from enum import IntEnum
+
+
+class DTDElementCount(IntEnum):
+    """
+    DTDElementCount determines how many times an element can be used
+    This
+    """
+    OnlyOne = 1
+    OneOrMore = 2
+    ZeroOrMore = 3
+    ZeroOrOne = 4
+
+
+class DTDElement:
+    """
+    DTDAttribute represents a DTD attribute as a name and how many
+    times it can occur. The information about the children is kept
+    in the DTD parser.
+    """
+    def __init__(self, element_name: str = "", occurrences: DTDElementCount = DTDElementCount.OnlyOne):
+        self.element_name = element_name
+        self.occurrences = occurrences
+        self.sub_elements = []
+
+    # def _debug_print(self):
+    #     print("Element: " + self.element_name)
+    #     print("Occurrences: " + self.occurrences.name)
+    #     print()


### PR DESCRIPTION
DTDElement is used to represent the child elements
of a DTD element by the dtd_parser.
DTDElement either stores a single element value or
a list of sub-elements when they are enclosed in parentheses