### PR TITLE
Fix DTD Attribute class: remove enumerated value

### DIFF
--- a/src/dtd_attribute/dtd_attribute.py
+++ b/src/dtd_attribute/dtd_attribute.py
@@ -51,7 +51,6 @@ class DTDAttribute:
         self.value_type = value_type
         self.value = value
         self.enumerated_values = []
-        self.enumerated_default_value = ""
 
     # def _debug_print(self):
     #     print("Element: " + self.element_name)
@@ -62,5 +61,4 @@ class DTDAttribute:
     #     if self.attribute_type == DTDAttributeType.Enumerated:
     #         print("Enumerated values")
     #         print(self.enumerated_values)
-    #         print("Default value: " + self.enumerated_default_value)
     #     print()

--- a/src/dtd_element/dtd_element.py
+++ b/src/dtd_element/dtd_element.py
@@ -26,4 +26,5 @@ class DTDElement:
     # def _debug_print(self):
     #     print("Element: " + self.element_name)
     #     print("Occurrences: " + self.occurrences.name)
+    #     print("Sub elements:" + str(len(self.sub_elements)))
     #     print()

--- a/src/dtd_parser/dtd_parser.py
+++ b/src/dtd_parser/dtd_parser.py
@@ -153,7 +153,9 @@ class DTDParser:
             split_all = list(filter(None, re.split(r'[)(>|]+', token_after_attribute_name)))
             attribute.attribute_type = DTDAttributeType.Enumerated
             attribute.value_type = DTDAttributeValueType.VALUE
-            attribute.enumerated_default_value = split_all[-1].strip('" ')
+            attribute.value = split_all[-1].strip('" ')
+            if attribute.value == "#IMPLIED" or attribute.value == "#REQUIRED":
+                attribute.value = ""
             attribute.enumerated_values = [value.strip('" ') for value in split_all[:-1]]
         else:
             # Non-enumerated attribute


### PR DESCRIPTION
Remove default enumerated value from DTDAttribute.
The field self.value is now used to store the default
enumerated value. default_enumerated_value was used
only by the dtd_parser. It's now changed to properly
use the field value instead.
DTDElement debug print is changed to better print the state
of the object. Now it prints the number of sub elements,
which is more relevant when debugging.