### PR TITLE
Fix dtd_parser (remove constructor params)

### DIFF
--- a/src/dtd_parser/dtd_parser.py
+++ b/src/dtd_parser/dtd_parser.py
@@ -29,16 +29,13 @@ def _split_on_whitespace(token: str, splits: int) -> list:
 
 
 class DTDParser:
-    def __init__(self, path=None):
-        self._path = path
+    def __init__(self):
+        self._path = ""
         self._content = ""
         self._parents_count = dict()
         self._tokens = dict()
         self.attributes = dict()
         self.elements = dict()
-
-        if self._path is not None:
-            self.parse_file(path)
 
     def _reset_state(self) -> None:
         """

--- a/test/dtd_parser/test_read_file_content.py
+++ b/test/dtd_parser/test_read_file_content.py
@@ -8,7 +8,8 @@ class TestDTDParserReadFileContent(unittest.TestCase):
         self.dataPath = ProjectPath.get_project_data_dtd_path()
 
     def test_1element(self):
-        parser = DTDParser(self.dataPath / '1element.dtd')
+        parser = DTDParser()
+        parser.parse_file(self.dataPath / '1element.dtd')
         self.assertEqual(parser._content.strip(), "<!ELEMENT note (#PCDATA)>")
 
     def test_2nested_elements(self):

--- a/test/dtd_parser/test_read_file_content_exceptions.py
+++ b/test/dtd_parser/test_read_file_content_exceptions.py
@@ -8,7 +8,8 @@ class TestDTDParserReadFileContentExceptions(unittest.TestCase):
         self.dataPath = ProjectPath.get_project_data_dtd_path()
 
     def test_file_not_found(self):
-        self.assertRaises(FileNotFoundError, DTDParser, self.dataPath / '.file_does_not_exist_gibberish.dtd.')
+        parser = DTDParser()
+        self.assertRaises(FileNotFoundError, parser.parse_file, self.dataPath / '.file_does_not_exist_gibberish.dtd.')
 
     def test_non_dtd_tags(self):
         parser = DTDParser()

--- a/test/dtd_parser/test_root_finding.py
+++ b/test/dtd_parser/test_root_finding.py
@@ -8,21 +8,26 @@ class TestDTDParserReadFileContent(unittest.TestCase):
         self.dataPath = ProjectPath.get_project_data_dtd_path()
 
     def test_1element(self):
-        parser = DTDParser(self.dataPath / '1element.dtd')
+        parser = DTDParser()
+        parser.parse_file(self.dataPath / '1element.dtd')
         self.assertEqual(parser.get_root(), "note")
 
     def test_2nested_elements(self):
-        parser = DTDParser(self.dataPath / '2nested_elements.dtd')
+        parser = DTDParser()
+        parser.parse_file(self.dataPath / '2nested_elements.dtd')
         self.assertEqual(parser.get_root(), "note")
 
     def test_11elements_6attributes(self):
-        parser = DTDParser(self.dataPath / '11elements_6attributes.dtd')
+        parser = DTDParser()
+        parser.parse_file(self.dataPath / '11elements_6attributes.dtd')
         self.assertEqual(parser.get_root(), "Course_Catalog")
 
     def test_9elements_3attributes(self):
-        parser = DTDParser(self.dataPath / '9elements_3attributes.dtd')
+        parser = DTDParser()
+        parser.parse_file(self.dataPath / '9elements_3attributes.dtd')
         self.assertEqual(parser.get_root(), "games")
 
     def test_14elements_2attributes(self):
-        parser = DTDParser(self.dataPath / '14elements_2attributes.dtd')
+        parser = DTDParser()
+        parser.parse_file(self.dataPath / '14elements_2attributes.dtd')
         self.assertEqual(parser.get_root(), "Course_Catalog")

--- a/test/xml_generator/test_xml_generator.py
+++ b/test/xml_generator/test_xml_generator.py
@@ -9,39 +9,45 @@ class TestXMLGenerator(unittest.TestCase):
         self.dataPath = ProjectPath.get_project_data_dtd_path()
 
     def test_1element(self):
-        parser = DTDParser(self.dataPath / '1element.dtd')
+        parser = DTDParser()
+        parser.parse_file(self.dataPath / '1element.dtd')
         generator = XMLGenerator(parser)
         generator.generate_xml()
         self.assertEqual(generator.to_string(), '<note />')
         self.assertEqual(generator.get_xml().get_root().tag, 'note')
 
     def test_2nested_elements(self):
-        parser = DTDParser(self.dataPath / '2nested_elements.dtd')
+        parser = DTDParser()
+        parser.parse_file(self.dataPath / '2nested_elements.dtd')
         generator = XMLGenerator(parser)
         generator.generate_xml()
         self.assertEqual(generator.to_string(), '<note><heading /></note>')
 
     def test_1element_1attribute(self):
-        parser = DTDParser(self.dataPath / '1element_1attribute.dtd')
+        parser = DTDParser()
+        parser.parse_file(self.dataPath / '1element_1attribute.dtd')
         generator = XMLGenerator(parser)
         generator.generate_xml()
         self.assertEqual(generator.to_string(), '<square width="0" />')
 
     def test_5nested_elements(self):
-        parser = DTDParser(self.dataPath / '5nested_elements.dtd')
+        parser = DTDParser()
+        parser.parse_file(self.dataPath / '5nested_elements.dtd')
         generator = XMLGenerator(parser)
         generator.generate_xml()
         self.assertEqual(generator.to_string(), '<note><to /><from /><heading /><body /></note>')
 
     def test_1element_6attributes(self):
-        parser = DTDParser(self.dataPath / '1element_6attributes.dtd')
+        parser = DTDParser()
+        parser.parse_file(self.dataPath / '1element_6attributes.dtd')
         generator = XMLGenerator(parser)
         generator.generate_xml()
         self.assertEqual(generator.to_string(), '<square width="0" number="" fax="" company="Microsoft" type="cash" '
                                                 'title="Mr or Mrs" />')
 
     def test_11elements_6attributes(self):
-        parser = DTDParser(self.dataPath / '11elements_6attributes.dtd')
+        parser = DTDParser()
+        parser.parse_file(self.dataPath / '11elements_6attributes.dtd')
         generator = XMLGenerator(parser)
         generator.generate_xml()
         self.assertEqual(generator.to_string(), '<Course_Catalog Year="2017-2018"><Department Code=""><Title '
@@ -51,7 +57,8 @@ class TestXMLGenerator(unittest.TestCase):
                                                 '/></Lecturer></Department></Course_Catalog>')
 
     def test_9elements_3attributes(self):
-        parser = DTDParser(self.dataPath / '9elements_3attributes.dtd')
+        parser = DTDParser()
+        parser.parse_file(self.dataPath / '9elements_3attributes.dtd')
         generator = XMLGenerator(parser)
         generator.generate_xml()
         self.assertEqual(generator.to_string(), '<games><game score=""><home-team /><ex-team /><scores><score time="" '
@@ -59,7 +66,8 @@ class TestXMLGenerator(unittest.TestCase):
                                                 '/></yellows><reds><player /></reds></game></games>')
 
     def test_14elements_2attributes(self):
-        parser = DTDParser(self.dataPath / '14elements_2attributes.dtd')
+        parser = DTDParser()
+        parser.parse_file(self.dataPath / '14elements_2attributes.dtd')
         generator = XMLGenerator(parser)
         generator.generate_xml()
         self.assertEqual(generator.to_string(), '<Course_Catalog><Department Code=""><Title '


### PR DESCRIPTION
Remove constructor parameters from dtd_parser
Fix the corresponding unit tests to not use the constructor
to load files, but instead use the new dtd_parser.parse_file