### PR TITLE
Test DTD parser get_root()

### DIFF
--- a/data/dtd/no_root.dtd
+++ b/data/dtd/no_root.dtd
@@ -1,0 +1,2 @@
+<!ELEMENT A (B)>
+<!ELEMENT B (A)>

--- a/src/dtd_parser/dtd_parser.py
+++ b/src/dtd_parser/dtd_parser.py
@@ -469,7 +469,7 @@ class DTDParser:
         for x in self._parents_count.keys():
             if self._parents_count[x] == 0:
                 return x
-        return ""
+        raise ValueError("No root exists for the provided DTD")
 
         # def _debug_print_attributes(self) -> None:
         #     """

--- a/test/dtd_parser/test_root_finding.py
+++ b/test/dtd_parser/test_root_finding.py
@@ -7,27 +7,8 @@ class TestDTDParserReadFileContent(unittest.TestCase):
     def setUp(self) -> None:
         self.dataPath = ProjectPath.get_project_data_dtd_path()
 
-    def test_1element(self):
+    def test_no_root(self):
         parser = DTDParser()
-        parser.parse_file(self.dataPath / '1element.dtd')
-        self.assertEqual(parser.get_root(), "note")
+        parser.parse_file(self.dataPath / 'no_root.dtd')
+        self.assertRaises(ValueError, parser.get_root)
 
-    def test_2nested_elements(self):
-        parser = DTDParser()
-        parser.parse_file(self.dataPath / '2nested_elements.dtd')
-        self.assertEqual(parser.get_root(), "note")
-
-    def test_11elements_6attributes(self):
-        parser = DTDParser()
-        parser.parse_file(self.dataPath / '11elements_6attributes.dtd')
-        self.assertEqual(parser.get_root(), "Course_Catalog")
-
-    def test_9elements_3attributes(self):
-        parser = DTDParser()
-        parser.parse_file(self.dataPath / '9elements_3attributes.dtd')
-        self.assertEqual(parser.get_root(), "games")
-
-    def test_14elements_2attributes(self):
-        parser = DTDParser()
-        parser.parse_file(self.dataPath / '14elements_2attributes.dtd')
-        self.assertEqual(parser.get_root(), "Course_Catalog")

--- a/test/dtd_parser/test_root_finding_exceptions.py
+++ b/test/dtd_parser/test_root_finding_exceptions.py
@@ -1,0 +1,33 @@
+import unittest
+from src.dtd_parser.dtd_parser import DTDParser
+from src.project_path.project_path import ProjectPath
+
+
+class TestDTDParserReadFileContent(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dataPath = ProjectPath.get_project_data_dtd_path()
+
+    def test_1element(self):
+        parser = DTDParser()
+        parser.parse_file(self.dataPath / '1element.dtd')
+        self.assertEqual(parser.get_root(), "note")
+
+    def test_2nested_elements(self):
+        parser = DTDParser()
+        parser.parse_file(self.dataPath / '2nested_elements.dtd')
+        self.assertEqual(parser.get_root(), "note")
+
+    def test_11elements_6attributes(self):
+        parser = DTDParser()
+        parser.parse_file(self.dataPath / '11elements_6attributes.dtd')
+        self.assertEqual(parser.get_root(), "Course_Catalog")
+
+    def test_9elements_3attributes(self):
+        parser = DTDParser()
+        parser.parse_file(self.dataPath / '9elements_3attributes.dtd')
+        self.assertEqual(parser.get_root(), "games")
+
+    def test_14elements_2attributes(self):
+        parser = DTDParser()
+        parser.parse_file(self.dataPath / '14elements_2attributes.dtd')
+        self.assertEqual(parser.get_root(), "Course_Catalog")

--- a/test/xml_generator/test_xml_generator.py
+++ b/test/xml_generator/test_xml_generator.py
@@ -77,3 +77,10 @@ class TestXMLGenerator(unittest.TestCase):
                                                 '/></Lecturer><Professor><First_Name /><Middle_Initial /><Last_Name '
                                                 '/></Professor></Instructors><Prerequisites><Prereq '
                                                 '/></Prerequisites></Course></Department></Course_Catalog>')
+
+    def test_nested_child_elements(self):
+        parser = DTDParser()
+        parser.parse_file(self.dataPath / 'nested_child_elements.dtd')
+        generator = XMLGenerator(parser)
+        generator.generate_xml()
+        self.assertEqual(generator.to_string(), '<D><A /><B /><C /></D>')


### PR DESCRIPTION
Fix DTDParser.get_root() to check for cycles
and lack of a root element.
Add test for DTD without root
Add test for XML generator for nested child elements